### PR TITLE
Use new vector-tile based flatmap viewer.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/flatmaps"]
 	path = src/flatmaps
-	url = https://github.com/alan-wu/flatmaps.git
+	url = git@github.com:dbrnz/flatmap-mvt-viewer.git


### PR DESCRIPTION
FWIW, `npm run build` succeeds after doing `npm install` in `src/flatmaps`.

Where though is the server code??